### PR TITLE
Couple of cleanups I found when deploying to a clean environment

### DIFF
--- a/aptly/aptly_config.sls
+++ b/aptly/aptly_config.sls
@@ -46,8 +46,13 @@ aptly_gpg_key_dir:
 
 {% set gpgprivfile = '{}/.gnupg/secret.gpg'.format(salt['pillar.get']('aptly:homedir', '/var/lib/aptly')) %}
 # goes in a different path so it's fetchable by the pkgrepo module
-{% set gpgpubfile = '{}/public.gpg'.format(salt['pillar.get']('aptly:rootdir', '/var/lib/aptly/.aptly')) %}
+{% set gpgpubfile = '{}/public/public.gpg'.format(salt['pillar.get']('aptly:rootdir', '/var/lib/aptly/.aptly')) %}
 {% set gpgid = salt['pillar.get']('aptly:gpg_keypair_id', '') %}
+
+{{ salt['pillar.get']('aptly:rootdir', '/var/lib/aptly/.aptly') }}/public:
+  file.directory:
+    - user: aptly
+    - group: aptly
 
 gpg_priv_key:
   file:


### PR DESCRIPTION
The gpg key has to actually be a level deeper than I was originally putting it
so the clients can access it via the web server.
