### PR TITLE
Add notes

### DIFF
--- a/aptly/aptly_config.sls
+++ b/aptly/aptly_config.sls
@@ -79,18 +79,18 @@ gpg_pub_key:
 import_gpg_pub_key:
   cmd:
     - run
-    - name: gpg --import {{ gpgpubfile }}
+    - name: gpg --no-tty --import {{ gpgpubfile }}
     - user: aptly
-    - unless: gpg --list-keys | grep '{{ gpgid }}'
+    - unless: gpg --no-tty --list-keys | grep '{{ gpgid }}'
     - require:
       - file: aptly_gpg_key_dir
 
 import_gpg_priv_key:
   cmd:
     - run
-    - name: gpg --allow-secret-key-import --import {{ gpgprivfile }}
+    - name: gpg --no-tty --allow-secret-key-import --import {{ gpgprivfile }}
     - user: aptly
-    - unless: gpg --list-secret-keys | grep '{{ gpgid }}'
+    - unless: gpg --no-tty --list-secret-keys | grep '{{ gpgid }}'
     - require:
       - file: aptly_gpg_key_dir
 {% endif %}

--- a/aptly/publish_repos.sls
+++ b/aptly/publish_repos.sls
@@ -8,7 +8,12 @@ include:
 publish_{{ repo }}_repo:
   cmd:
     - run
+    # NOTE: You may have to run this command manually the first time. The next
+    # version of aptly is supposed to have a -batch option to pass -no-tty to
+    # the gpg calls.
     - name: aptly publish repo -gpg-key='{{ gpgid }}' -passphrase='{{ gpgpassphrase }}' {{ repo }}
     - user: aptly
+    # unless is 2014.7 only, on 2014.1 it doesn't run and you just get an error
+    # saying the repo has already been published
     - unless: aptly publish update -gpg-key='{{ gpgid }}' -passphrase='{{ gpgpassphrase }}' {{ opts['distribution'] }}
 {% endfor %}


### PR DESCRIPTION
Add notes mentioning some possible manual steps to work around an aptly bug and a 2014.1 limitation.

This is also showing commits from another branch that should be merged first.