### PR TITLE
Add option to install nightly version

### DIFF
--- a/aptly/init.sls
+++ b/aptly/init.sls
@@ -1,8 +1,13 @@
 aptly_repo:
   pkgrepo.managed:
     - humanname: Aptly PPA
+{% if not salt['pillar.get']('aptly:install_nightly', False) %}
     - name: deb http://repo.aptly.info/ squeeze main
     - dist: squeeze
+{% else %}
+    - name: deb http://repo.aptly.info/ nightly main
+    - dist: nightly
+{% endif %}
     - file: /etc/apt/sources.list.d/aptly.list
     - keyid: 2A194991
     - keyserver: keys.gnupg.net
@@ -10,13 +15,13 @@ aptly_repo:
       - pkg: aptly
 
 aptly:
-  pkg.installed:
+  pkg.latest:
     - name: aptly
     - refresh: True
 
 # dependency for publishing
 bzip2:
-  pkg.installed:
+  pkg.installed
 
 aptly_user:
   user.present:

--- a/aptly/publish_repos.sls
+++ b/aptly/publish_repos.sls
@@ -4,15 +4,15 @@ include:
 {% set gpgid = salt['pillar.get']('aptly:gpg_keypair_id', '') %}
 {% set gpgpassphrase = salt['pillar.get']('aptly:gpg_passphrase', '') %}
 
-{% for repo, opts in salt['pillar.get']('aptly:repos').items() %}
+{% for repo, opts in salt['pillar.get']('aptly:repos', {}).items() %}
 publish_{{ repo }}_repo:
   cmd.run:
-    # NOTE: You may have to run this command manually the first time. The next
-    # version of aptly is supposed to have a -batch option to pass -no-tty to
-    # the gpg calls.
+  {% if not salt['pillar.get']('aptly:install_nightly', False) %}
     - name: aptly publish repo -gpg-key='{{ gpgid }}' -passphrase='{{ gpgpassphrase }}' {{ repo }}
-    - user: aptly
-    # unless is 2014.7 only, on 2014.1 it doesn't run and you just get an error
-    # saying the repo has already been published
     - unless: aptly publish update -gpg-key='{{ gpgid }}' -passphrase='{{ gpgpassphrase }}' {{ opts['distribution'] }}
+  {% else %}
+    - name: aptly -batch=true publish repo -gpg-key='{{ gpgid }}' -passphrase='{{ gpgpassphrase }}' {{ repo }}
+    - unless: aptly -batch=true publish update -gpg-key='{{ gpgid }}' -passphrase='{{ gpgpassphrase }}' {{ opts['distribution'] }}
+  {% endif %}
+    - user: aptly
 {% endfor %}

--- a/pillar.example
+++ b/pillar.example
@@ -2,6 +2,8 @@
 aptly:
   homedir: /var/lib/aptly
   rootdir: /var/lib/aptly/repo
+  # if you get errors about tty's or just failing when it shouldn't, enable this
+  install_nightly: False
   repos:
     repo01:
       distribution: wheezy


### PR DESCRIPTION
The nightly version (i.e. the next aptly release) will have an option to allow
better functionality when run from within salt (-batch mode). Use this nightly
build and alter the formula functionality to match.