### PR TITLE
Add HOME env variable to cmd.run's

### DIFF
--- a/aptly/aptly_config.sls
+++ b/aptly/aptly_config.sls
@@ -76,6 +76,8 @@ import_gpg_pub_key:
     - name: gpg --no-tty --import {{ gpgpubfile }}
     - user: aptly
     - unless: gpg --no-tty --list-keys | grep '{{ gpgid }}'
+    - env:
+      - HOME: {{ salt['pillar.get']('aptly:homedir', '/var/lib/aptly') }}
     - require:
       - file: aptly_gpg_key_dir
 
@@ -84,6 +86,8 @@ import_gpg_priv_key:
     - name: gpg --no-tty --allow-secret-key-import --import {{ gpgprivfile }}
     - user: aptly
     - unless: gpg --no-tty --list-secret-keys | grep '{{ gpgid }}'
+    - env:
+      - HOME: {{ salt['pillar.get']('aptly:homedir', '/var/lib/aptly') }}
     - require:
       - file: aptly_gpg_key_dir
 {% endif %}

--- a/aptly/create_repos.sls
+++ b/aptly/create_repos.sls
@@ -10,6 +10,8 @@ create_{{ repo }}_repo:
     - name: aptly repo create -distribution="{{ opts['distribution'] }}" -comment="{{ opts['comment'] }}" {{ repo }}
     - unless: aptly repo show {{ repo }}
     - user: aptly
+    - env:
+      - HOME: {{ salt['pillar.get']('aptly:homedir', '/var/lib/aptly') }}
     - require:
       - sls: aptly.aptly_config
 
@@ -18,6 +20,8 @@ add_{{ repo }}_pkgs:
   cmd.run:
     - name: aptly repo add {{ repo }} {{ opts['pkgdir'] }}
     - user: aptly
+    - env:
+      - HOME: {{ salt['pillar.get']('aptly:homedir', '/var/lib/aptly') }}
     - require:
       - cmd: create_{{ repo }}_repo
   {% endif %}

--- a/aptly/publish_repos.sls
+++ b/aptly/publish_repos.sls
@@ -12,6 +12,8 @@ publish_{{ repo }}_repo:
     # the gpg calls.
     - name: aptly publish repo -gpg-key='{{ gpgid }}' -passphrase='{{ gpgpassphrase }}' {{ repo }}
     - user: aptly
+    - env:
+      - HOME: {{ salt['pillar.get']('aptly:homedir', '/var/lib/aptly') }}
     # unless is 2014.7 only, on 2014.1 it doesn't run and you just get an error
     # saying the repo has already been published
     - unless: aptly publish update -gpg-key='{{ gpgid }}' -passphrase='{{ gpgpassphrase }}' {{ opts['distribution'] }}


### PR DESCRIPTION
2015.2 doesn't seem to pass the env correctly. This shouldn't impact anything
<2015.2 and fixes an issue in 2015.2.