### PR TITLE
Add -batch=true option to aptly commands

### DIFF
--- a/aptly/create_repos.sls
+++ b/aptly/create_repos.sls
@@ -7,8 +7,8 @@ include:
 {% for repo, opts in salt['pillar.get']('aptly:repos').items() %}
 create_{{ repo }}_repo:
   cmd.run:
-    - name: aptly repo create -distribution="{{ opts['distribution'] }}" -comment="{{ opts['comment'] }}" {{ repo }}
-    - unless: aptly repo show {{ repo }}
+    - name: aptly -batch=true repo create -distribution="{{ opts['distribution'] }}" -comment="{{ opts['comment'] }}" {{ repo }}
+    - unless: aptly -batch=true repo show {{ repo }}
     - user: aptly
     - env:
       - HOME: {{ salt['pillar.get']('aptly:homedir', '/var/lib/aptly') }}
@@ -18,7 +18,7 @@ create_{{ repo }}_repo:
   {% if opts['pkgdir'] %}
 add_{{ repo }}_pkgs:
   cmd.run:
-    - name: aptly repo add {{ repo }} {{ opts['pkgdir'] }}
+    - name: aptly -batch=true repo add {{ repo }} {{ opts['pkgdir'] }}
     - user: aptly
     - env:
       - HOME: {{ salt['pillar.get']('aptly:homedir', '/var/lib/aptly') }}

--- a/aptly/publish_repos.sls
+++ b/aptly/publish_repos.sls
@@ -10,11 +10,11 @@ publish_{{ repo }}_repo:
     # NOTE: You may have to run this command manually the first time. The next
     # version of aptly is supposed to have a -batch option to pass -no-tty to
     # the gpg calls.
-    - name: aptly publish repo -gpg-key='{{ gpgid }}' -passphrase='{{ gpgpassphrase }}' {{ repo }}
+    - name: aptly -batch=true publish repo -gpg-key='{{ gpgid }}' -passphrase='{{ gpgpassphrase }}' {{ repo }}
     - user: aptly
     - env:
       - HOME: {{ salt['pillar.get']('aptly:homedir', '/var/lib/aptly') }}
     # unless is 2014.7 only, on 2014.1 it doesn't run and you just get an error
     # saying the repo has already been published
-    - unless: aptly publish update -gpg-key='{{ gpgid }}' -passphrase='{{ gpgpassphrase }}' {{ opts['distribution'] }}
+    - unless: aptly -batch=true publish update -gpg-key='{{ gpgid }}' -passphrase='{{ gpgpassphrase }}' {{ opts['distribution'] }}
 {% endfor %}


### PR DESCRIPTION
The -batch=true option tells aptly to pass -no-tty to gpg commands (amongst
other things). It's required to not have the underlying gpg calls complain.