### PR TITLE
-batch option is only for publish commands

### DIFF
--- a/aptly/create_repos.sls
+++ b/aptly/create_repos.sls
@@ -7,8 +7,8 @@ include:
 {% for repo, opts in salt['pillar.get']('aptly:repos').items() %}
 create_{{ repo }}_repo:
   cmd.run:
-    - name: aptly -batch=true repo create -distribution="{{ opts['distribution'] }}" -comment="{{ opts['comment'] }}" {{ repo }}
-    - unless: aptly -batch=true repo show {{ repo }}
+    - name: aptly repo create -distribution="{{ opts['distribution'] }}" -comment="{{ opts['comment'] }}" {{ repo }}
+    - unless: aptly repo show {{ repo }}
     - user: aptly
     - env:
       - HOME: {{ salt['pillar.get']('aptly:homedir', '/var/lib/aptly') }}
@@ -18,7 +18,7 @@ create_{{ repo }}_repo:
   {% if opts['pkgdir'] %}
 add_{{ repo }}_pkgs:
   cmd.run:
-    - name: aptly -batch=true repo add {{ repo }} {{ opts['pkgdir'] }}
+    - name: aptly repo add {{ repo }} {{ opts['pkgdir'] }}
     - user: aptly
     - env:
       - HOME: {{ salt['pillar.get']('aptly:homedir', '/var/lib/aptly') }}


### PR DESCRIPTION
I was using a pre-release version before. It just ignored the -batch option for !publish commands. The release version dies :sadface: