### PR TITLE
Add template:jinja to nginx template

### DIFF
--- a/aptly/nginx.sls
+++ b/aptly/nginx.sls
@@ -6,6 +6,7 @@ aptly_site:
   file.managed:
     - name: /etc/nginx/sites-enabled/aptly
     - source: salt://aptly/files/aptly.jinja
+    - template: jinja
     - mode: 644
     - user: root
     - group: root


### PR DESCRIPTION
I don't use the formulas nginx support, so I never noticed this was broken.

fixes #14