### PR TITLE
Make the formula stop reporting changes when all packages already added

### DIFF
--- a/aptly/create_repos.sls
+++ b/aptly/create_repos.sls
@@ -5,17 +5,23 @@ include:
   - aptly.aptly_config
 
 {% for repo, opts in salt['pillar.get']('aptly:repos').items() %}
+  {% set homedir = salt['pillar.get']('aptly:homedir', '/var/lib/aptly') %}
+
 create_{{ repo }}_repo:
   cmd.run:
     - name: aptly repo create -distribution="{{ opts['distribution'] }}" -comment="{{ opts['comment'] }}" {{ repo }}
     - unless: aptly repo show {{ repo }}
     - user: aptly
     - env:
-      - HOME: {{ salt['pillar.get']('aptly:homedir', '/var/lib/aptly') }}
+      - HOME: {{ homedir }}
     - require:
       - sls: aptly.aptly_config
 
   {% if opts['pkgdir'] %}
+    {% set numcurrentpkgs = salt['cmd.run']('aptly repo show ' ~ repo ~ ' | tail -n1 | cut -f4 -d" "', user='aptly', env="[{\'HOME\':\'' ~ homedir ~ '\'}]") %}
+    {% set pkgsinpkgdir = salt['file.find']('/srv/dist/dist/repo', type='f', iregex='.*(deb|udeb|dsc)$')|count %}
+    {% if numcurrentpkgs == pkgsinpkgdir %}
+      {# we already have all the packages loaded, skip #}
 add_{{ repo }}_pkgs:
   cmd.run:
     - name: aptly repo add {{ repo }} {{ opts['pkgdir'] }}
@@ -24,6 +30,7 @@ add_{{ repo }}_pkgs:
       - HOME: {{ salt['pillar.get']('aptly:homedir', '/var/lib/aptly') }}
     - require:
       - cmd: create_{{ repo }}_repo
+    {% endif %}
   {% endif %}
 
 {% endfor %}


### PR DESCRIPTION
Before we just blindly added all the packages all the time, but that made it
look like things were constantly changing. Check the number of packages in the
repo against the number of packages in the pkgdir, if it matches, skip adding.