### PR TITLE
added possibility specify archs explicitly

### DIFF
--- a/aptly/files/.aptly.conf.jinja
+++ b/aptly/files/.aptly.conf.jinja
@@ -1,7 +1,7 @@
 {
   "rootDir": "{{ salt['pillar.get']('aptly:rootdir') }}",
   "downloadConcurrency": 4,
-  "architectures": [{{ salt['pillar.get']('aptly:architectures') }}],
+  "architectures": [{{ salt['pillar.get']('aptly:architectures', '') }}],
   "dependencyFollowSuggests": false,
   "dependencyFollowRecommends": false,
   "dependencyFollowAllVariants": false,

--- a/aptly/files/.aptly.conf.jinja
+++ b/aptly/files/.aptly.conf.jinja
@@ -1,7 +1,7 @@
 {
   "rootDir": "{{ salt['pillar.get']('aptly:rootdir') }}",
   "downloadConcurrency": 4,
-  "architectures": [],
+  "architectures": [{{ salt['pillar.get']('aptly:architectures') }}],
   "dependencyFollowSuggests": false,
   "dependencyFollowRecommends": false,
   "dependencyFollowAllVariants": false,

--- a/pillar.example
+++ b/pillar.example
@@ -1,6 +1,7 @@
 aptly:
   homedir: /var/lib/aptly
   rootdir: /var/lib/aptly/repo
+  architectures: '"amd64", "i386", "all", "source"'
   repos:
     repo01:
       components:


### PR DESCRIPTION
This commit fixes an error, which I met:
`              stderr:
                  ERROR: unable to publish: unable to figure out list of architectures, please supply explicit list
`
