### PR TITLE
 cleaning up aptly state for flexibility

### DIFF
--- a/aptly/aptly_config.sls
+++ b/aptly/aptly_config.sls
@@ -16,6 +16,7 @@ aptly_rootdir:
     - user: aptly
     - group: aptly
     - mode: 755
+    - makedirs: True
     - require:
       - file: aptly_homedir
 

--- a/aptly/create_repos.sls
+++ b/aptly/create_repos.sls
@@ -19,7 +19,7 @@ create_{{ repo_name }}_repo:
     - require:
       - sls: aptly.aptly_config
 
-      {% if opts['pkgdir'] %}
+      {% if opts.get('pkgdir', false) %}
 {{ opts['pkgdir'] }}/{{ distribution }}/{{ component }}:
   file.directory:
     - user: root

--- a/aptly/files/.aptly.conf.jinja
+++ b/aptly/files/.aptly.conf.jinja
@@ -1,7 +1,7 @@
 {
   "rootDir": "{{ salt['pillar.get']('aptly:rootdir') }}",
   "downloadConcurrency": 4,
-  "architectures": [{{ salt['pillar.get']('aptly:architectures', '') }}],
+  "architectures": {{ salt['pillar.get']('aptly:architectures', [])|json }},
   "dependencyFollowSuggests": false,
   "dependencyFollowRecommends": false,
   "dependencyFollowAllVariants": false,

--- a/aptly/init.sls
+++ b/aptly/init.sls
@@ -25,3 +25,10 @@ aptly_user:
     - home: {{ salt['pillar.get']('aptly:homedir', '/var/lib/aptly') }}
     - require:
       - pkg: aptly
+    {% if salt['pillar.get']('aptly:user:uid', 0) %}
+    - uid: {{ salt['pillar.get']('aptly:user:uid') }}
+    {% endif %}
+    {% if salt['pillar.get']('aptly:user:gid', 0) %}
+    - gid: {{ salt['pillar.get']('aptly:user:gid') }}
+    - gid_from_name: True
+    {% endif %}

--- a/aptly/publish_repos.sls
+++ b/aptly/publish_repos.sls
@@ -3,8 +3,10 @@ include:
 
 {% set gpgid = salt['pillar.get']('aptly:gpg_keypair_id', '') %}
 {% set gpgpassphrase = salt['pillar.get']('aptly:gpg_passphrase', '') %}
+{% set optional_args = [ ('gpg-key', gpgid), ('passphrase', gpgpassphrase) ] %}
 {% for repo, opts in salt['pillar.get']('aptly:repos').items() %}
   {% set components_list = opts['components']|join(',') %}
+  {% set prefix = opts.get('prefix', '') %} 
   {% for distribution in opts['distributions'] %}
     {% set repo_list = [] %}
     {% for component in opts['components'] %}
@@ -15,12 +17,12 @@ publish_{{ repo }}_{{ distribution }}_repo:
     # NOTE: You may have to run this command manually the first time. The next
     # version of aptly is supposed to have a -batch option to pass -no-tty to
     # the gpg calls.
-    - name: aptly -batch=true publish repo -distribution="{{ distribution }}" -component="{{ components_list }}" -gpg-key='{{ gpgid }}' -passphrase='{{ gpgpassphrase }}' {{ repo_list|join(' ') }}
+    - name: aptly publish repo -batch=true -distribution="{{ distribution }}" -architectures='{{ salt["pillar.get"]('aptly:architectures')|join(",") }}' {% for arg in optional_args %} {% if arg[1] %} {{ "-{}={}".format(arg[0], arg[1]) }} {% endif %} {% endfor %}  {{ repo_list|join(' ') }} {% if prefix  %} {{ prefix }} {% endif %}
     - user: aptly
     - env:
       - HOME: {{ salt['pillar.get']('aptly:homedir', '/var/lib/aptly') }}
     # unless is 2014.7 only, on 2014.1 it doesn't run and you just get an error
     # saying the repo has already been published
-    - unless: aptly -batch=true publish update -gpg-key='{{ gpgid }}' -passphrase='{{ gpgpassphrase }}' {{ distribution }}
+    - unless: aptly -batch=true publish update -gpg-key='{{ gpgid }}' {{ distribution }} {% if prefix  %} {{ prefix }} {% endif %}
   {% endfor %}
 {% endfor %}

--- a/pillar.example
+++ b/pillar.example
@@ -1,7 +1,11 @@
 aptly:
   homedir: /var/lib/aptly
   rootdir: /var/lib/aptly/repo
-  architectures: '"amd64", "i386", "all", "source"'
+  architectures:
+    - amd64
+    - i386
+    - all
+    - source
   repos:
     repo01:
       components:


### PR DESCRIPTION
just a little cleanup

- ```opts['pkgdir']``` fails if you dont specify it. in the case that I do no want to (our setup), this should be optional so switched to defaulting the value to ```false``` as to not fail the states
- instead of passing ```architectures``` as a string with stringed comma-delimited values (in the hope that it parses out correctly), just accept an array and pass it through salts json filter
- optional ```uid``` and ```gid```
- ```publish_repos``` now takes an optional ```prefix``` . 
- ```publish_repos``` also makes ```gpg-keyid``` and ```gpgpassphrase``` optional and only appends them if available