### PR TITLE
 adding backwards compatiblity for architectures field

### DIFF
--- a/aptly/files/.aptly.conf.jinja
+++ b/aptly/files/.aptly.conf.jinja
@@ -1,7 +1,13 @@
+{% set architectures = salt['pillar.get']('aptly:architectures', []) %}
 {
   "rootDir": "{{ salt['pillar.get']('aptly:rootdir') }}",
   "downloadConcurrency": 4,
-  "architectures": {{ salt['pillar.get']('aptly:architectures', [])|json }},
+  {# this is to remain backwards compatability to when pillars accepted a comma delimited string, preferred method is a list #}
+  {%- if architectures is string -%}
+  "architectures": [{{ architectures }}],
+  {% else %}
+  "architectures": {{ architectures|json }},
+  {%- endif -%}
   "dependencyFollowSuggests": false,
   "dependencyFollowRecommends": false,
   "dependencyFollowAllVariants": false,


### PR DESCRIPTION
as per @iggy  comment here: https://github.com/saltstack-formulas/aptly-formula/pull/27#issuecomment-228245988

We could also do this in one line, but this looks a little cleaner. would be happy to move to one line if necessary