### PR TITLE
Bf aptly formula issue 30

### DIFF
--- a/aptly/create_mirrors.sls
+++ b/aptly/create_mirrors.sls
@@ -24,14 +24,27 @@ create_{{ mirror }}_mirror:
       - HOME: {{ homedir }}
     - require:
       - sls: aptly.aptly_config
+{% if opts['keyids'] is defined %}
+{% for keyid in opts['keyids'] %}
+      - cmd: add_{{ keyid }}_gpg_key
+{% endfor %}
+
+{% for keyid in opts['keyids'] %}
+add_{{keyid}}_gpg_key:
+  cmd.run:
+    - name: gpg --no-default-keyring --keyring {{ keyring }} --keyserver {{ opts['keyserver']|default('keys.gnupg.net') }} --recv-keys {{keyid}}
+    - user: aptly
+{% endfor %}
+  {% elif opts['keyid'] is defined %}
       - cmd: add_{{ mirror }}_gpg_key
 
-  {% if opts['keyid'] is defined %}
 add_{{ mirror }}_gpg_key:
   cmd.run:
     - name: gpg --no-default-keyring --keyring {{ keyring }} --keyserver {{ opts['keyserver']|default('keys.gnupg.net') }} --recv-keys {{ opts['keyid'] }}
     - user: aptly
   {% elif opts['key_url'] is defined %}
+      - cmd: add_{{ mirror }}_gpg_key
+
 add_{{ mirror }}_gpg_key:
   cmd.run:
     - name: gpg --no-default-keyring --keyring {{ keyring }} --fetch-keys {{ opts['key_url'] }}

--- a/pillar.example
+++ b/pillar.example
@@ -18,6 +18,17 @@ aptly:
       comment: "Software Repo"
       pkgdir: /srv/pkgs
   mirrors:
+    google-earth-main:
+      url: http://dl.google.com/linux/earth/deb/
+      distribution: stable
+      components:
+        - main
+      keyids:
+        - 7FAC5991
+        - 640DB551
+      architectures:
+        - amd64
+      prefix: "google-earth-main"
     salt-main:
       url: http://repo.saltstack.com/apt/ubuntu/ubuntu14/latest
       distribution: trusty

--- a/pillar.example
+++ b/pillar.example
@@ -34,7 +34,8 @@ aptly:
       distribution: trusty
       components:
         - main
-      keyid: DE57BFBE
+      keyid:
+        - DE57BFBE
       architectures:
         - amd64
   secure: True


### PR DESCRIPTION
Many repositories need more than one key in the gpg keyring to allow mirroring.

This PR fixes https://github.com/saltstack-formulas/aptly-formula/issues/30
