### PR TITLE
Don't run this state every highstate

### DIFF
--- a/aptly/create_repos.sls
+++ b/aptly/create_repos.sls
@@ -36,6 +36,8 @@ add_{{ repo_name }}_pkgs:
     - user: aptly
     - env:
       - HOME: {{ homedir }}
+    - onlyif:
+      - find {{ opts['pkgdir'] }}/{{ distribution }}/{{ component }} -type f -mindepth 1 -print -quit | grep -q .
     - require:
       - cmd: create_{{ repo_name }}_repo
         {% endif %}


### PR DESCRIPTION
A simple check ensures that the state is only run when required, making state.highstate test=True more useful