### PR TITLE
Only call keyring server when we need to.

### DIFF
--- a/aptly/create_mirrors.sls
+++ b/aptly/create_mirrors.sls
@@ -4,7 +4,9 @@ include:
   - aptly
   - aptly.aptly_config
 
+{% if salt['pillar.get']('aptly:mirrors') %}
 {% for mirror, opts in salt['pillar.get']('aptly:mirrors').items() %}
+  {% set mirrorloop = mirror %}
   {%- set homedir = salt['pillar.get']('aptly:homedir', '/var/lib/aptly') -%}
   {%- set keyring = salt['pillar.get']('aptly:keyring', 'trustedkeys.gpg') -%}
   {%- if opts['url'] is defined -%}
@@ -26,14 +28,15 @@ create_{{ mirror }}_mirror:
       - sls: aptly.aptly_config
 {% if opts['keyids'] is defined %}
 {% for keyid in opts['keyids'] %}
-      - cmd: add_{{ keyid }}_gpg_key
+      - cmd: add_{{ mirrorloop }}_{{ keyid }}_gpg_key
 {% endfor %}
 
 {% for keyid in opts['keyids'] %}
-add_{{keyid}}_gpg_key:
+add_{{ mirrorloop }}_{{keyid}}_gpg_key:
   cmd.run:
     - name: gpg --no-default-keyring --keyring {{ keyring }} --keyserver {{ opts['keyserver']|default('keys.gnupg.net') }} --recv-keys {{keyid}}
     - user: aptly
+    - unless: gpg --list-keys --keyring {{ keyring }}  | grep {{keyid}}
 {% endfor %}
   {% elif opts['keyid'] is defined %}
       - cmd: add_{{ mirror }}_gpg_key
@@ -42,6 +45,7 @@ add_{{ mirror }}_gpg_key:
   cmd.run:
     - name: gpg --no-default-keyring --keyring {{ keyring }} --keyserver {{ opts['keyserver']|default('keys.gnupg.net') }} --recv-keys {{ opts['keyid'] }}
     - user: aptly
+    - unless: gpg --list-keys --keyring {{ keyring }}  | grep {{ opts['keyid'] }}
   {% elif opts['key_url'] is defined %}
       - cmd: add_{{ mirror }}_gpg_key
 
@@ -49,5 +53,7 @@ add_{{ mirror }}_gpg_key:
   cmd.run:
     - name: gpg --no-default-keyring --keyring {{ keyring }} --fetch-keys {{ opts['key_url'] }}
     - user: aptly
+    - unless: gpg --list-keys --keyring {{ keyring }}  | grep {{keyid}}
   {% endif %}
 {% endfor %}
+{% endif %}


### PR DESCRIPTION
Fix for https://github.com/saltstack-formulas/aptly-formula/issues/35

In addition:
1) Support using the same keyring for different repos without failing.
2) Allow the formula to be a no op if no mirrors defined.

Signed-off-by: Owen Synge <owen.synge@jaysnest.de>