### PR TITLE
FIX version conflict behavior

### DIFF
--- a/aptly/publish_repos.sls
+++ b/aptly/publish_repos.sls
@@ -17,12 +17,12 @@ publish_{{ repo }}_{{ distribution }}_repo:
     # NOTE: You may have to run this command manually the first time. The next
     # version of aptly is supposed to have a -batch option to pass -no-tty to
     # the gpg calls.
-    - name: aptly publish repo -batch=true -distribution="{{ distribution }}" -component='{{ components_list }}' -architectures='{{ salt["pillar.get"]('aptly:architectures')|join(",") }}' {% for arg in optional_args %} {% if arg[1] %} {{ "-{}={}".format(arg[0], arg[1]) }} {% endif %} {% endfor %}  {{ repo_list|join(' ') }} {% if prefix  %} {{ prefix }} {% endif %}
+    - name: aptly publish repo -force-overwrite=true -batch=true -distribution="{{ distribution }}" -component='{{ components_list }}' -architectures='{{ salt["pillar.get"]('aptly:architectures')|join(",") }}' {% for arg in optional_args %} {% if arg[1] %} {{ "-{}={}".format(arg[0], arg[1]) }} {% endif %} {% endfor %}  {{ repo_list|join(' ') }} {% if prefix  %} {{ prefix }} {% endif %}
     - user: aptly
     - env:
       - HOME: {{ salt['pillar.get']('aptly:homedir', '/var/lib/aptly') }}
     # unless is 2014.7 only, on 2014.1 it doesn't run and you just get an error
     # saying the repo has already been published
-    - unless: aptly publish -batch=true update -gpg-key='{{ gpgid }}' {{ distribution }} {% if prefix  %} {{ prefix }} {% endif %}
+    - unless: aptly publish update -force-overwrite=true -batch=true -gpg-key='{{ gpgid }}' {{ distribution }} {% if prefix  %} {{ prefix }} {% endif %}
   {% endfor %}
 {% endfor %}


### PR DESCRIPTION
if we upload already existing version of package to upload dir, aptlu will fail without this flag.
If we will use this flag, aptly would overwrite file.