### PR TITLE
Allow to specify the gpg command to use

### DIFF
--- a/aptly/aptly_config.sls
+++ b/aptly/aptly_config.sls
@@ -1,3 +1,5 @@
+{% set gpg_command = salt['pillar.get']('aptly:gpg_command', 'gpg') %}
+
 include:
   - aptly
 
@@ -74,9 +76,9 @@ gpg_pub_key:
 
 import_gpg_pub_key:
   cmd.run:
-    - name: gpg --no-tty --import {{ gpgpubfile }}
+    - name: { gpg_command }} --no-tty --import {{ gpgpubfile }}
     - user: aptly
-    - unless: gpg --no-tty --list-keys | grep '{{ gpgid }}'
+    - unless: { gpg_command }} --no-tty --list-keys | grep '{{ gpgid }}'
     - env:
       - HOME: {{ salt['pillar.get']('aptly:homedir', '/var/lib/aptly') }}
     - require:
@@ -84,9 +86,9 @@ import_gpg_pub_key:
 
 import_gpg_priv_key:
   cmd.run:
-    - name: gpg --no-tty --allow-secret-key-import --import {{ gpgprivfile }}
+    - name: { gpg_command }} --no-tty --allow-secret-key-import --import {{ gpgprivfile }}
     - user: aptly
-    - unless: gpg --no-tty --list-secret-keys | grep '{{ gpgid }}'
+    - unless: { gpg_command }} --no-tty --list-secret-keys | grep '{{ gpgid }}'
     - env:
       - HOME: {{ salt['pillar.get']('aptly:homedir', '/var/lib/aptly') }}
     - require:

--- a/aptly/create_mirrors.sls
+++ b/aptly/create_mirrors.sls
@@ -1,5 +1,7 @@
 # Set up our Aptly mirrors
 
+{% set gpg_command = salt['pillar.get']('aptly:gpg_command', 'gpg') %}
+
 include:
   - aptly
   - aptly.aptly_config
@@ -34,26 +36,26 @@ create_{{ mirror }}_mirror:
 {% for keyid in opts['keyids'] %}
 add_{{ mirrorloop }}_{{keyid}}_gpg_key:
   cmd.run:
-    - name: gpg --no-default-keyring --keyring {{ keyring }} --keyserver {{ opts['keyserver']|default('keys.gnupg.net') }} --recv-keys {{keyid}}
+    - name: { gpg_command }} --no-default-keyring --keyring {{ keyring }} --keyserver {{ opts['keyserver']|default('keys.gnupg.net') }} --recv-keys {{keyid}}
     - user: aptly
-    - unless: gpg --list-keys --keyring {{ keyring }}  | grep {{keyid}}
+    - unless: { gpg_command }} --list-keys --keyring {{ keyring }}  | grep {{keyid}}
 {% endfor %}
   {% elif opts['keyid'] is defined %}
       - cmd: add_{{ mirror }}_gpg_key
 
 add_{{ mirror }}_gpg_key:
   cmd.run:
-    - name: gpg --no-default-keyring --keyring {{ keyring }} --keyserver {{ opts['keyserver']|default('keys.gnupg.net') }} --recv-keys {{ opts['keyid'] }}
+    - name: { gpg_command }} --no-default-keyring --keyring {{ keyring }} --keyserver {{ opts['keyserver']|default('keys.gnupg.net') }} --recv-keys {{ opts['keyid'] }}
     - user: aptly
-    - unless: gpg --list-keys --keyring {{ keyring }}  | grep {{ opts['keyid'] }}
+    - unless: { gpg_command }} --list-keys --keyring {{ keyring }}  | grep {{ opts['keyid'] }}
   {% elif opts['key_url'] is defined %}
       - cmd: add_{{ mirror }}_gpg_key
 
 add_{{ mirror }}_gpg_key:
   cmd.run:
-    - name: gpg --no-default-keyring --keyring {{ keyring }} --fetch-keys {{ opts['key_url'] }}
+    - name: { gpg_command }} --no-default-keyring --keyring {{ keyring }} --fetch-keys {{ opts['key_url'] }}
     - user: aptly
-    - unless: gpg --list-keys --keyring {{ keyring }}  | grep {{keyid}}
+    - unless: { gpg_command }} --list-keys --keyring {{ keyring }}  | grep {{keyid}}
   {% endif %}
 {% endfor %}
 {% endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -50,6 +50,7 @@ aptly:
       storageClass: ""
       encryptionMethod: ""
       plusWorkaround: "false"
+  gpg_command: 'gpg'
   gpg_keypair_id: 00000000
   gpg_passphrase: 'my voice is my passport'
   gpg_pub_key: |

--- a/pillar.example
+++ b/pillar.example
@@ -34,7 +34,7 @@ aptly:
       distribution: trusty
       components:
         - main
-      keyid:
+      keyids:
         - DE57BFBE
       architectures:
         - amd64


### PR DESCRIPTION
Hello,

This PR allows to use another *gnupg* command. It should help on *Debian Stretch+* systems which  use *gnupg 2.x* by default.

See https://www.aptly.info/doc/feature/pgp-providers/ for details.

It should not affect existing setups.

Thanks.