### PR TITLE
Use runas argument for cmd.run instead of user

### DIFF
--- a/aptly/aptly_config.sls
+++ b/aptly/aptly_config.sls
@@ -77,7 +77,7 @@ gpg_pub_key:
 import_gpg_pub_key:
   cmd.run:
     - name: { gpg_command }} --no-tty --import {{ gpgpubfile }}
-    - user: aptly
+    - runas: aptly
     - unless: { gpg_command }} --no-tty --list-keys | grep '{{ gpgid }}'
     - env:
       - HOME: {{ salt['pillar.get']('aptly:homedir', '/var/lib/aptly') }}
@@ -87,7 +87,7 @@ import_gpg_pub_key:
 import_gpg_priv_key:
   cmd.run:
     - name: { gpg_command }} --no-tty --allow-secret-key-import --import {{ gpgprivfile }}
-    - user: aptly
+    - runas: aptly
     - unless: { gpg_command }} --no-tty --list-secret-keys | grep '{{ gpgid }}'
     - env:
       - HOME: {{ salt['pillar.get']('aptly:homedir', '/var/lib/aptly') }}

--- a/aptly/create_mirrors.sls
+++ b/aptly/create_mirrors.sls
@@ -23,7 +23,7 @@ create_{{ mirror }}_mirror:
   cmd.run:
     - name: {{ create_mirror_cmd }}
     - unless: aptly mirror show {{ mirror }}
-    - user: aptly
+    - runas: aptly
     - env:
       - HOME: {{ homedir }}
     - require:
@@ -37,7 +37,7 @@ create_{{ mirror }}_mirror:
 add_{{ mirrorloop }}_{{keyid}}_gpg_key:
   cmd.run:
     - name: { gpg_command }} --no-default-keyring --keyring {{ keyring }} --keyserver {{ opts['keyserver']|default('keys.gnupg.net') }} --recv-keys {{keyid}}
-    - user: aptly
+    - runas: aptly
     - unless: { gpg_command }} --list-keys --keyring {{ keyring }}  | grep {{keyid}}
 {% endfor %}
   {% elif opts['keyid'] is defined %}
@@ -46,7 +46,7 @@ add_{{ mirrorloop }}_{{keyid}}_gpg_key:
 add_{{ mirror }}_gpg_key:
   cmd.run:
     - name: { gpg_command }} --no-default-keyring --keyring {{ keyring }} --keyserver {{ opts['keyserver']|default('keys.gnupg.net') }} --recv-keys {{ opts['keyid'] }}
-    - user: aptly
+    - runas: aptly
     - unless: { gpg_command }} --list-keys --keyring {{ keyring }}  | grep {{ opts['keyid'] }}
   {% elif opts['key_url'] is defined %}
       - cmd: add_{{ mirror }}_gpg_key
@@ -54,7 +54,7 @@ add_{{ mirror }}_gpg_key:
 add_{{ mirror }}_gpg_key:
   cmd.run:
     - name: { gpg_command }} --no-default-keyring --keyring {{ keyring }} --fetch-keys {{ opts['key_url'] }}
-    - user: aptly
+    - runas: aptly
     - unless: { gpg_command }} --list-keys --keyring {{ keyring }}  | grep {{keyid}}
   {% endif %}
 {% endfor %}

--- a/aptly/create_repos.sls
+++ b/aptly/create_repos.sls
@@ -13,7 +13,7 @@ create_{{ repo_name }}_repo:
   cmd.run:
     - name: aptly repo create -distribution="{{ distribution }}" -comment="{{ opts['comment'] }}" -component="{{ component }}" {{ repo_name }}
     - unless: aptly repo show {{ repo_name }}
-    - user: aptly
+    - runas: aptly
     - env:
       - HOME: {{ homedir }}
     - require:
@@ -33,7 +33,7 @@ create_{{ repo_name }}_repo:
 add_{{ repo_name }}_pkgs:
   cmd.run:
     - name: aptly repo add -force-replace=true -remove-files=true {{ repo_name }} {{ opts['pkgdir'] }}/{{ distribution }}/{{ component }}
-    - user: aptly
+    - runas: aptly
     - env:
       - HOME: {{ homedir }}
     - onlyif:

--- a/aptly/publish_repos.sls
+++ b/aptly/publish_repos.sls
@@ -18,7 +18,7 @@ publish_{{ repo }}_{{ distribution }}_repo:
     # version of aptly is supposed to have a -batch option to pass -no-tty to
     # the gpg calls.
     - name: aptly publish repo -force-overwrite=true -batch=true -distribution="{{ distribution }}" -component='{{ components_list }}' -architectures='{{ salt["pillar.get"]('aptly:architectures')|join(",") }}' {% for arg in optional_args %} {% if arg[1] %} {{ "-{}={}".format(arg[0], arg[1]) }} {% endif %} {% endfor %}  {{ repo_list|join(' ') }} {% if prefix  %} {{ prefix }} {% endif %}
-    - user: aptly
+    - runas: aptly
     - env:
       - HOME: {{ salt['pillar.get']('aptly:homedir', '/var/lib/aptly') }}
     # unless is 2014.7 only, on 2014.1 it doesn't run and you just get an error


### PR DESCRIPTION
Hello,

The *runas* argument should be used with *cmd.run* instead of *user", which has been deprecated a long time ago. See https://github.com/saltstack/salt/issues/11179 for details.

Thanks.