### PR TITLE
Support filter and filter-with-deps arguments

### DIFF
--- a/aptly/create_mirrors.sls
+++ b/aptly/create_mirrors.sls
@@ -55,5 +55,26 @@ add_{{ mirror }}_gpg_key:
     - runas: aptly
     - unless: {{ aptly.gpg_command }} --list-keys --keyring {{ aptly.gpg_keyring }}  | grep {{keyid}}
   {% endif %}
+
+{# Edit mirror to setup filters when needed #}
+{%- if opts['filter'] is defined -%}
+  {%- set edit_mirror_cmd = "aptly mirror edit" -%}
+  {%- set filter_args = "-filter '" ~ opts['filter']|default([])|join(' | ') ~ "'" -%}
+
+  {%- if opts['filter-with-deps'] is defined -%}
+    {%- if opts['filter-with-deps'] == True -%}
+      {%- set filter_args = filter_args + " -filter-with-deps" -%}
+    {% endif %}
+  {% endif %}
+
+edit_{{ mirror }}_mirror:
+  cmd.run:
+    - name: {{ edit_mirror_cmd }} {{ filter_args }} {{ mirror }}
+    - runas: aptly
+    - onlyif: aptly mirror show {{ mirror }}
+    - env:
+      - HOME: {{ aptly.homedir }}
+{% endif %}
+
 {% endfor %}
 {% endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -49,6 +49,19 @@ aptly:
         - DE57BFBE
       architectures:
         - amd64
+    stretch:
+      url: http://ftp.fr.debian.org/debian/
+      distribution: stretch
+      components:
+        - main
+      architectures:
+        - amd64
+      filter:
+        - Priority (required)
+        - Priority (important)
+        - Priority (standard)
+        - bash
+      filter-with-deps: true
   s3Endpoints:
     test:
       region: us-west-2


### PR DESCRIPTION
Hello,

The *aptly mirror* command supports *-filter* and *-filter-with-deps* arguments which allow to create mirrors on a per packages query basis.

See https://www.aptly.info/doc/feature/query/ for details.

Thanks.