### PR TITLE
Add import for aptly from Jinja template

### DIFF
--- a/aptly/create_repos.sls
+++ b/aptly/create_repos.sls
@@ -1,5 +1,7 @@
 # Set up our Aptly repos
 
+{% from "aptly/map.jinja" import aptly with context %}
+
 include:
   - aptly
   - aptly.aptly_config


### PR DESCRIPTION
aptly.create_repos is broken due to a missing import from map.jinja, causing a render error:

```
root@master:~# salt-call state.apply aptly.create_repos
[ERROR   ] Rendering exception occurred: Jinja variable 'aptly' is undefined
[CRITICAL] Rendering SLS 'base:aptly.create_repos' failed: Jinja variable 'aptly' is undefined
local:
    Data failed to compile:
----------
    Rendering SLS 'base:aptly.create_repos' failed: Jinja variable 'aptly' is undefined
```

The import fixes it.