### PR TITLE
Made the user configurable

### DIFF
--- a/aptly/aptly_config.sls
+++ b/aptly/aptly_config.sls
@@ -9,14 +9,14 @@ aptly_homedir:
   file.directory:
     - name: {{ aptly.homedir }}
     - user: {{ aptly.username }}
-    - group: {{ aptly.username }}
+    - group: {{ aptly.groupname }}
     - mode: 755
 
 aptly_rootdir:
   file.directory:
     - name: {{ aptly.rootdir }}
     - user: {{ aptly.username }}
-    - group: {{ aptly.username }}
+    - group: {{ aptly.groupname }}
     - mode: 755
     - makedirs: True
     - require:
@@ -28,7 +28,7 @@ aptly_conf:
     - source: salt://aptly/files/.aptly.conf.jinja
     - template: jinja
     - user: {{ aptly.username }}
-    - group: {{ aptly.username }}
+    - group: {{ aptly.groupname }}
     - mode: 664
     - require:
       - file: aptly_homedir
@@ -38,7 +38,7 @@ aptly_gpg_key_dir:
   file.directory:
     - name: {{ aptly.homedir }}/.gnupg
     - user: {{ aptly.username }}
-    - group: {{ aptly.username }}
+    - group: {{ aptly.groupname }}
     - mode: 700
     - require:
       - file: aptly_homedir
@@ -51,14 +51,14 @@ aptly_pubdir:
   file.directory:
     - name: {{ aptly.rootdir }}/public
     - user: {{ aptly.username }}
-    - group: {{ aptly.username }}
+    - group: {{ aptly.groupname }}
 
 gpg_priv_key:
   file.managed:
     - name: {{ gpgprivfile }}
     - contents_pillar: aptly:gpg_priv_key
     - user: {{ aptly.username }}
-    - group: {{ aptly.username }}
+    - group: {{ aptly.groupname }}
     - mode: 700
     - require:
       - file: aptly_gpg_key_dir
@@ -68,7 +68,7 @@ gpg_pub_key:
     - name: {{ gpgpubfile }}
     - contents_pillar: aptly:gpg_pub_key
     - user: {{ aptly.username }}
-    - group: {{ aptly.username }}
+    - group: {{ aptly.groupname }}
     - mode: 755
     - require:
       - file: aptly_gpg_key_dir

--- a/aptly/aptly_config.sls
+++ b/aptly/aptly_config.sls
@@ -8,15 +8,15 @@ include:
 aptly_homedir:
   file.directory:
     - name: {{ aptly.homedir }}
-    - user: aptly
-    - group: aptly
+    - user: {{ aptly.username }}
+    - group: {{ aptly.username }}
     - mode: 755
 
 aptly_rootdir:
   file.directory:
     - name: {{ aptly.rootdir }}
-    - user: aptly
-    - group: aptly
+    - user: {{ aptly.username }}
+    - group: {{ aptly.username }}
     - mode: 755
     - makedirs: True
     - require:
@@ -27,8 +27,8 @@ aptly_conf:
     - name: {{ aptly.homedir }}/.aptly.conf
     - source: salt://aptly/files/.aptly.conf.jinja
     - template: jinja
-    - user: aptly
-    - group: aptly
+    - user: {{ aptly.username }}
+    - group: {{ aptly.username }}
     - mode: 664
     - require:
       - file: aptly_homedir
@@ -37,8 +37,8 @@ aptly_conf:
 aptly_gpg_key_dir:
   file.directory:
     - name: {{ aptly.homedir }}/.gnupg
-    - user: aptly
-    - group: aptly
+    - user: {{ aptly.username }}
+    - group: {{ aptly.username }}
     - mode: 700
     - require:
       - file: aptly_homedir
@@ -50,15 +50,15 @@ aptly_gpg_key_dir:
 aptly_pubdir:
   file.directory:
     - name: {{ aptly.rootdir }}/public
-    - user: aptly
-    - group: aptly
+    - user: {{ aptly.username }}
+    - group: {{ aptly.username }}
 
 gpg_priv_key:
   file.managed:
     - name: {{ gpgprivfile }}
     - contents_pillar: aptly:gpg_priv_key
-    - user: aptly
-    - group: aptly
+    - user: {{ aptly.username }}
+    - group: {{ aptly.username }}
     - mode: 700
     - require:
       - file: aptly_gpg_key_dir
@@ -67,8 +67,8 @@ gpg_pub_key:
   file.managed:
     - name: {{ gpgpubfile }}
     - contents_pillar: aptly:gpg_pub_key
-    - user: aptly
-    - group: aptly
+    - user: {{ aptly.username }}
+    - group: {{ aptly.username }}
     - mode: 755
     - require:
       - file: aptly_gpg_key_dir
@@ -76,7 +76,7 @@ gpg_pub_key:
 import_gpg_pub_key:
   cmd.run:
     - name: {{ aptly.gpg_command }} --no-tty --import {{ gpgpubfile }}
-    - runas: aptly
+    - runas: {{ aptly.username }}
     - unless: {{ aptly.gpg_command }} --no-tty --list-keys | grep '{{ gpgid }}'
     - env:
       - HOME: {{ aptly.homedir }}
@@ -86,7 +86,7 @@ import_gpg_pub_key:
 import_gpg_priv_key:
   cmd.run:
     - name: {{ aptly.gpg_command }} --no-tty --allow-secret-key-import --import {{ gpgprivfile }}
-    - runas: aptly
+    - runas: {{ aptly.username }}
     - unless: {{ aptly.gpg_command }} --no-tty --list-secret-keys | grep '{{ gpgid }}'
     - env:
       - HOME: {{ aptly.homedir }}

--- a/aptly/create_mirrors.sls
+++ b/aptly/create_mirrors.sls
@@ -21,7 +21,7 @@ create_{{ mirror }}_mirror:
   cmd.run:
     - name: {{ create_mirror_cmd }}
     - unless: {{ aptly.aptly_command }} mirror show {{ mirror }}
-    - runas: aptly
+    - runas: {{ aptly.username }}
     - env:
       - HOME: {{ aptly.homedir }}
     - require:
@@ -35,7 +35,7 @@ create_{{ mirror }}_mirror:
 add_{{ mirrorloop }}_{{ keyid }}_gpg_key:
   cmd.run:
     - name: {{ aptly.gpg_command }} --no-default-keyring --keyring {{ aptly.gpg_keyring }} --keyserver {{ opts['keyserver']|default('keys.gnupg.net') }} --recv-keys {{ keyid }}
-    - runas: aptly
+    - runas: {{ aptly.username }}
     - unless: {{ aptly.gpg_command }} --list-keys --keyring {{ aptly.gpg_keyring }} | grep {{ keyid }}
 {% endfor %}
   {% elif opts['keyid'] is defined %}
@@ -44,7 +44,7 @@ add_{{ mirrorloop }}_{{ keyid }}_gpg_key:
 add_{{ mirror }}_gpg_key:
   cmd.run:
     - name: {{ aptly.gpg_command }} --no-default-keyring --keyring {{ aptly.gpg_keyring }} --keyserver {{ opts['keyserver']|default('keys.gnupg.net') }} --recv-keys {{ opts['keyid'] }}
-    - runas: aptly
+    - runas: {{ aptly.username }}
     - unless: {{ aptly.gpg_command }} --list-keys --keyring {{ aptly.gpg_keyring }} | grep {{ opts['keyid'] }}
   {% elif opts['key_url'] is defined %}
       - cmd: add_{{ mirror }}_gpg_key
@@ -52,7 +52,7 @@ add_{{ mirror }}_gpg_key:
 add_{{ mirror }}_gpg_key:
   cmd.run:
     - name: {{ aptly.gpg_command }} --no-default-keyring --keyring {{ aptly.gpg_keyring }} --fetch-keys {{ opts['key_url'] }}
-    - runas: aptly
+    - runas: {{ aptly.username }}
     - unless: {{ aptly.gpg_command }} --list-keys --keyring {{ aptly.gpg_keyring }} | grep {{ keyid }}
   {% endif %}
 
@@ -70,7 +70,7 @@ add_{{ mirror }}_gpg_key:
 edit_{{ mirror }}_mirror:
   cmd.run:
     - name: {{ edit_mirror_cmd }} {{ filter_args }} {{ mirror }}
-    - runas: aptly
+    - runas: {{ aptly.username }}
     - onlyif: {{ aptly.aptly_command }} mirror show {{ mirror }}
     - env:
       - HOME: {{ aptly.homedir }}

--- a/aptly/create_repos.sls
+++ b/aptly/create_repos.sls
@@ -27,7 +27,7 @@ create_{{ repo_name }}_repo:
     - group: root
     - mode: 777
     - makedirs: True
-        {% set numcurrentpkgs = salt['cmd.run'](aptly.aptly_command ~ ' repo show ' ~ repo_name ~ ' | tail -n1 | cut -f4 -d" "', user='aptly', env="[{\'HOME\':\'' ~ homedir ~ '\'}]") %}
+        {% set numcurrentpkgs = salt['cmd.run'](aptly.aptly_command ~ ' repo show ' ~ repo_name ~ ' | tail -n1 | cut -f4 -d" "', user=aptly.username, env="[{\'HOME\':\'' ~ homedir ~ '\'}]") %}
         {% set pkgsinpkgdir = salt['file.find']('/srv/dist/dist/repo', type='f', iregex='.*(deb|udeb|dsc)$')|count %}
         {% if numcurrentpkgs != pkgsinpkgdir %}
           {# we dont  have all the packages loaded, add all packages in opts['pkgdir'] #}

--- a/aptly/create_repos.sls
+++ b/aptly/create_repos.sls
@@ -14,7 +14,7 @@ create_{{ repo_name }}_repo:
   cmd.run:
     - name: {{ aptly.aptly_command }} repo create -distribution="{{ distribution }}" -comment="{{ opts['comment'] }}" -component="{{ component }}" {{ repo_name }}
     - unless: {{ aptly.aptly_command }} repo show {{ repo_name }}
-    - runas: aptly
+    - runas: {{ aptly.username }}
     - env:
       - HOME: {{ aptly.homedir }}
     - require:
@@ -34,7 +34,7 @@ create_{{ repo_name }}_repo:
 add_{{ repo_name }}_pkgs:
   cmd.run:
     - name: {{ aptly.aptly_command }} repo add -force-replace=true -remove-files=true {{ repo_name }} {{ opts['pkgdir'] }}/{{ distribution }}/{{ component }}
-    - runas: aptly
+    - runas: {{ aptly.username }}
     - env:
       - HOME: {{ aptly.homedir }}
     - onlyif:

--- a/aptly/init.sls
+++ b/aptly/init.sls
@@ -26,7 +26,7 @@ aptly_packages:
 {% if aptly.create_user %}
 aptly_user:
   group.present:
-    - name: {{ aptly.username }}
+    - name: {{ aptly.groupname }}
     {% if aptly.user.gid %}
     - gid: {{ aptly.user.gid }}
     {% endif %}

--- a/aptly/init.sls
+++ b/aptly/init.sls
@@ -26,12 +26,12 @@ aptly_packages:
 {% if aptly.create_user %}
 aptly_user:
   group.present:
-    - name: aptly
+    - name: {{ aptly.username }}
     {% if aptly.user.gid %}
     - gid: {{ aptly.user.gid }}
-    {% endif %} 
+    {% endif %}
   user.present:
-    - name: aptly
+    - name: {{ aptly.username }}
     - shell: /bin/bash
     - home: {{ aptly.homedir }}
     {% if aptly.install_packages %}

--- a/aptly/map.jinja
+++ b/aptly/map.jinja
@@ -9,6 +9,7 @@
       'aptly_command': 'aptly',
       'gpg_command': 'gpg',
       'gpg_keyring': 'trustedkeys.gpg',
+      'username': 'aptly',
       'user': {
         'uid': 0,
         'gid': 0,

--- a/aptly/map.jinja
+++ b/aptly/map.jinja
@@ -10,6 +10,7 @@
       'gpg_command': 'gpg',
       'gpg_keyring': 'trustedkeys.gpg',
       'username': 'aptly',
+      'groupname': 'aptly',
       'user': {
         'uid': 0,
         'gid': 0,

--- a/aptly/publish_repos.sls
+++ b/aptly/publish_repos.sls
@@ -11,7 +11,7 @@ include:
 {% set optional_args = [ ('gpg-key', gpgid), ('passphrase', gpgpassphrase) ] %}
 {% for repo, opts in repos.items() %}
   {% set components_list = opts['components']|join(',') %}
-  {% set prefix = opts.get('prefix', '') %} 
+  {% set prefix = opts.get('prefix', '') %}
   {% for distribution in opts['distributions'] %}
     {% set repo_list = [] %}
     {% for component in opts['components'] %}
@@ -23,7 +23,7 @@ publish_{{ repo }}_{{ distribution }}_repo:
     # version of aptly is supposed to have a -batch option to pass -no-tty to
     # the gpg calls.
     - name: {{ aptly.aptly_command }} publish repo -force-overwrite=true -batch=true -distribution="{{ distribution }}" -component='{{ components_list }}' -architectures='{{ architectures | join(",") }}' {% for arg in optional_args %} {% if arg[1] %} {{ "-{}={}".format(arg[0], arg[1]) }} {% endif %} {% endfor %}  {{ repo_list|join(' ') }} {% if prefix  %} {{ prefix }} {% endif %}
-    - runas: aptly
+    - runas: {{ aptly.username }}
     - env:
       - HOME: {{ aptly.homedir }}
     # unless is 2014.7 only, on 2014.1 it doesn't run and you just get an error

--- a/pillar.example
+++ b/pillar.example
@@ -8,6 +8,7 @@ aptly:
     secure: True
     gpg_command: 'gpg'
     gpg_keyring: 'trustedkeys.gpg'
+    username: aptly
     user:
       uid: 0
       gid: 0

--- a/pillar.example
+++ b/pillar.example
@@ -9,6 +9,7 @@ aptly:
     gpg_command: 'gpg'
     gpg_keyring: 'trustedkeys.gpg'
     username: aptly
+    groupname: aptly
     user:
       uid: 0
       gid: 0


### PR DESCRIPTION
The user is currently hardcoded to `aptly`. This is annoying, because changing this is practically impossible. 

I've tried to achieve this with a bunch of `extend:` entries but for instance in the `publish_repos` and `create_repos` which uses a loop. 

This PR adds the ability to change the user, it defaults to `aptly` in the pillar data and map so it should be perfectly backwards compatible with people who prefer to keep using the `aptly` user rather than a different one.