### PR TITLE
Fix create_repos: Ordering of find command arguments

### DIFF
--- a/aptly/create_repos.sls
+++ b/aptly/create_repos.sls
@@ -38,7 +38,7 @@ add_{{ repo_name }}_pkgs:
     - env:
       - HOME: {{ aptly.homedir }}
     - onlyif:
-      - find {{ opts['pkgdir'] }}/{{ distribution }}/{{ component }} -type f -mindepth 1 -print -quit | grep -q .
+      - find {{ opts['pkgdir'] }}/{{ distribution }}/{{ component }} -mindepth 1 -type f -print -quit | grep -q .
     - require:
       - cmd: create_{{ repo_name }}_repo
         {% endif %}


### PR DESCRIPTION
The current find ordering shows a warning:
```
find: warning: you have specified the -mindepth option after a non-option argument -type, but options are not positional (-mindepth affects tests specified before it as well as those specified after it).  Please specify options before other arguments.
```

This PR swaps around the order to remove this warning.