### PR TITLE
Fix #57

### DIFF
--- a/aptly/init.sls
+++ b/aptly/init.sls
@@ -14,6 +14,7 @@ aptly_repo:
 {% endif %}
 
 {% if aptly.install_packages %}
+{% if aptly.pkgs is defined %}
 aptly_packages:
   pkg.installed:
     - pkgs:
@@ -21,6 +22,7 @@ aptly_packages:
       - {{ pkg }}
       {% endfor %}
     - refresh: True
+{% endif %}
 {% endif %}
 
 {% if aptly.create_user %}

--- a/aptly/map.jinja
+++ b/aptly/map.jinja
@@ -19,4 +19,7 @@
     'Debian': {
       'pkgs': ['aptly', 'bzip2', 'gnupg1', 'gpgv1'],
     },
+    'RedHat': {
+      'pkgs': ['bzip2', 'gnupg2'],
+    },
 }, merge=salt['pillar.get']('aptly:lookup'), base='default') %}


### PR DESCRIPTION
Fixes #57

You'll need a locally built/installed copy of aptly on any RHEL based system as Aptly does not publish rpm's.